### PR TITLE
Proposed enhancement for sleep delay

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -258,7 +258,7 @@ resource "google_compute_instance" "f5vm01" {
   )
 
   provisioner "local-exec" {
-    command = "sleep 250"
+    command = "sleep ${var.sleep_secs}"
   }
   labels = var.labels
 }

--- a/main.tf
+++ b/main.tf
@@ -258,7 +258,8 @@ resource "google_compute_instance" "f5vm01" {
   )
 
   provisioner "local-exec" {
-    command = "sleep ${var.sleep_secs}"
+    command = format("%s %d", substr(pathexpand("~"), 0, 1) == "/" ? "sleep" : "start-sleep -s", var.sleep_secs)
+    interpreter = [substr(pathexpand("~"), 0, 1) == "/" ? "sh" : "powershell"]
   }
   labels = var.labels
 }

--- a/main.tf
+++ b/main.tf
@@ -259,7 +259,7 @@ resource "google_compute_instance" "f5vm01" {
 
   provisioner "local-exec" {
     command = format("%s %d", substr(pathexpand("~"), 0, 1) == "/" ? "sleep" : "start-sleep -s", var.sleep_secs)
-    interpreter = [substr(pathexpand("~"), 0, 1) == "/" ? "sh" : "powershell"]
+    interpreter = substr(pathexpand("~"), 0, 1) == "/" ? ["sh", "-c"] : ["powershell"]
   }
   labels = var.labels
 }

--- a/variables.tf
+++ b/variables.tf
@@ -198,3 +198,9 @@ variable "metadata" {
   default     = {}
 }
 
+variable "sleep_secs" {
+  type = number
+  default = 250
+  description = "The number of seconds of delay to build into creation of BIG-IP VMs; default is 250. BIG-IP requires a few minutes to complete the onboarding process and this value can be used to delay the processing of dependent Terraform resources."
+}
+


### PR DESCRIPTION
## Allow module consumer to override the local-exec sleep delay

Add a new variable `sleep_secs` that defaults to 250, but can be set by the caller where there are dependent modules or circular dependencies.

For example, a CFE deployment will require a GCP forwarding-rule that references the BIG-IP VMs created, and the CFE declaration that is passed to runtime-init will include the name/tags of the forwarding-rule. By reducing the sleep delay the module consumer is able to ensure that the forwarding-rule is created with correct BIG-IP VM targets *before* CFE initialisation is scanning for matching GCP resources.

Closes #9.

## Fix error when deploying on Windows

If HOME path starts with / assume the local-exec is running on a system with POSIX shell and `sleep`, if not execute PowerShell `start-sleep` equivalent.

Closes #8.