### PR TITLE
fix: Explicitly set DNS resolver during first boot

### DIFF
--- a/startup-script.tpl
+++ b/startup-script.tpl
@@ -221,6 +221,8 @@ if [[ ${NIC_COUNT} && ! -f /config/nicswap_finished ]]; then
    tmsh create sys management-route default gateway $${MGMTGATEWAY} mtu $${MGMTMTU}
    tmsh modify sys global-settings remote-host add { metadata.google.internal { hostname metadata.google.internal addr 169.254.169.254 } }
    tmsh modify sys management-dhcp sys-mgmt-dhcp-config request-options delete { ntp-servers }
+   echo "Setting DNS resolver to Cloud DNS"
+   tmsh modify sys dns name-servers add { 169.254.169.254 }
    tmsh save /sys config
    /usr/bin/touch /config/nicswap_finished
    reboot


### PR DESCRIPTION
This is a potential fix for issue #34; it explicitly adds GCE metadata endpoint as the DNS, at least until overridden by DO.