### PR TITLE
allow to use shared VPCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ module bigip {
   zone                = var.zone
   image               = var.image
   service_account     = var.service_account
-  mgmt_subnet_ids     = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "" }]
-  external_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.external_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "private_ip_secondary" = "" }]
-  internal_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.internal_subnetwork.id, "public_ip" = false, "private_ip_primary" = "", "private_ip_secondary" = "" }]
+  mgmt_subnet_ids     = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "network_id" = null, "subnet_project_id" = null }]
+  external_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.external_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "private_ip_secondary" = "", "network_id" = null, "subnet_project_id" = null }]
+  internal_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.internal_subnetwork.id, "public_ip" = false, "private_ip_primary" = "", "private_ip_secondary" = "", "network_id" = null, "subnet_project_id" = null }]
   custom_user_data       = var.custom_user_data
 }
 ```
@@ -150,7 +150,7 @@ module bigip {
   zone            = var.zone
   image           = var.image
   service_account = var.service_account
-  mgmt_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "" }]
+  mgmt_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "network_id" = null, "subnet_project_id" = null }]
 }
 
 #Example 2-NIC Deployment Module usage
@@ -163,8 +163,8 @@ module "bigip" {
   zone                = var.zone
   image               = var.image
   service_account     = var.service_account
-  mgmt_subnet_ids     = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "" }]
-  external_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.external_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "private_ip_secondary" = "" }]
+  mgmt_subnet_ids     = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "network_id" = null, "subnet_project_id" = null }]
+  external_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.external_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "private_ip_secondary" = "", "network_id" = null, "subnet_project_id" = null }]
 }
 
 #Example 3-NIC Deployment  Module usage 
@@ -177,9 +177,9 @@ module bigip {
   zone                = var.zone
   image               = var.image
   service_account     = var.service_account
-  mgmt_subnet_ids     = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "" }]
-  external_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.external_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "private_ip_secondary" = "" }]
-  internal_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.internal_subnetwork.id, "public_ip" = false, "private_ip_primary" = "", "private_ip_secondary" = "" }]
+  mgmt_subnet_ids     = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "network_id" = null, "subnet_project_id" = null }]
+  external_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.external_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "private_ip_secondary" = "", "network_id" = null, "subnet_project_id" = null }]
+  internal_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.internal_subnetwork.id, "public_ip" = false, "private_ip_primary" = "", "private_ip_secondary" = "", "network_id" = null, "subnet_project_id" = null }]
 }
 
 #Example 4-NIC Deployment  Module usage(with 2 external public interfaces,one management and internal interfaces)
@@ -192,9 +192,9 @@ module bigip {
   zone                = var.zone
   image               = var.image
   service_account     = var.service_account
-  mgmt_subnet_ids     = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "" }]
-  external_subnet_ids = ([{ "subnet_id" = google_compute_subnetwork.external_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "private_ip_secondary" = ""  },                                         { "subnet_id" = google_compute_subnetwork.external_subnetwork2.id, "public_ip" = true, "private_ip_primary" = "", "private_ip_secondary" = ""  }])
-  internal_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.internal_subnetwork.id, "public_ip" = false, "private_ip_primary" = "" }]
+  mgmt_subnet_ids     = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "network_id" = null, "subnet_project_id" = null }]
+  external_subnet_ids = ([{ "subnet_id" = google_compute_subnetwork.external_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "private_ip_secondary" = "", "network_id" = null, "subnet_project_id" = null  },                                         { "subnet_id" = google_compute_subnetwork.external_subnetwork2.id, "public_ip" = true, "private_ip_primary" = "", "private_ip_secondary" = "", "network_id" = null, "subnet_project_id" = null  }])
+  internal_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.internal_subnetwork.id, "public_ip" = false, "private_ip_primary" = "", "network_id" = null, "subnet_project_id" = null }]
 }
 ```
 
@@ -212,9 +212,9 @@ module bigip {
   zone                = var.zone
   image               = var.image
   service_account     = var.service_account
-  mgmt_subnet_ids     = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "" }]
-  external_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.external_subnetwork.id, "public_ip" = true, "private_ip_primary" = "10.2.1.2", "private_ip_secondary" = "10.2.1.3" }]
-  internal_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.internal_subnetwork.id, "public_ip" = false, "private_ip_primary" = "", "private_ip_secondary" = "" }]
+  mgmt_subnet_ids     = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "network_id" = null, "subnet_project_id" = null }]
+  external_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.external_subnetwork.id, "public_ip" = true, "private_ip_primary" = "10.2.1.2", "private_ip_secondary" = "10.2.1.3", "network_id" = null, "subnet_project_id" = null }]
+  internal_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.internal_subnetwork.id, "public_ip" = false, "private_ip_primary" = "", "private_ip_secondary" = "", "network_id" = null, "subnet_project_id" = null }]
 }
 ```
 
@@ -251,9 +251,9 @@ These variables have default values and don't have to be set to use this module.
 | gcp_secret_version | The version of the secret to get. If it is not provided, the latest version is retrieved | `string` | latest|
 | libs\_dir | Directory on the BIG-IP to download the A&O Toolchain into | `string` | /config/cloud/gcp/node_modules |
 | onboard\_log | Directory on the BIG-IP to store the cloud-init logs | `string` | /var/log/startup-script.log |
-| mgmt\_subnet\_ids | List of maps of subnetids of the virtual network where the virtual machines will reside | `List of Maps` | [{ "subnet_id" = null, "public_ip" = null,"private_ip_primary" = "" }] |
-| external\_subnet\_ids | List of maps of subnetids of the virtual network where the virtual machines will reside | `List of Maps` | [{ "subnet_id" = null, "public_ip" = null,"private_ip_primary" = "", "private_ip_secondary" = "" }] |
-| internal\_subnet\_ids | List of maps of subnetids of the virtual network where the virtual machines will reside | `List of Maps` | [{ "subnet_id" = null, "public_ip" = null,"private_ip_primary" = "" }] |
+| mgmt\_subnet\_ids | List of maps of subnetids of the virtual network where the virtual machines will reside | `List of Maps` | [{ "subnet_id" = null, "public_ip" = null,"private_ip_primary" = "", "network_id" = null, "subnet_project_id" = null }] |
+| external\_subnet\_ids | List of maps of subnetids of the virtual network where the virtual machines will reside | `List of Maps` | [{ "subnet_id" = null, "public_ip" = null,"private_ip_primary" = "", "private_ip_secondary" = "", "network_id" = null, "subnet_project_id" = null }] |
+| internal\_subnet\_ids | List of maps of subnetids of the virtual network where the virtual machines will reside | `List of Maps` | [{ "subnet_id" = null, "public_ip" = null,"private_ip_primary" = "", "network_id" = null, "subnet_project_id" = null }] |
 | DO_URL | URL to download the BIG-IP Declarative Onboarding module | `string` | `latest` Note: don't change name of ATC tools rpm file |
 | AS3_URL | URL to download the BIG-IP Application Service Extension 3 (AS3) module | `string` | `latest` Note: don't change name of ATC tools rpm file |
 | TS_URL | URL to download the BIG-IP Telemetry Streaming module | `string` | `latest` Note: don't change name of ATC tools rpm file |

--- a/examples/bigip_gcp_1nic_deploy/main.tf
+++ b/examples/bigip_gcp_1nic_deploy/main.tf
@@ -63,6 +63,6 @@ module "bigip" {
   image           = var.image
   sleep_time      = "1800s"
   service_account = google_service_account.f5_bigip_user.email
-  mgmt_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "" }]
+  mgmt_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "network_id" = null, "subnet_project_id" = null }]
 }
 

--- a/examples/bigip_gcp_1nic_deploy_custom_runtime_init/main.tf
+++ b/examples/bigip_gcp_1nic_deploy_custom_runtime_init/main.tf
@@ -57,7 +57,7 @@ module "bigip" {
   zone            = var.zone
   image           = var.image
   service_account = var.service_account
-  mgmt_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "" }]
+  mgmt_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "network_id" = null, "subnet_project_id" = null }]
   custom_user_data = templatefile("custom_onboard_big.tmpl",
     {
       onboard_log                       = var.onboard_log

--- a/examples/bigip_gcp_1nic_deploy_provider_integration/main.tf
+++ b/examples/bigip_gcp_1nic_deploy_provider_integration/main.tf
@@ -63,6 +63,6 @@ module "bigip" {
   image           = var.image
   sleep_time      = "1800s"
   service_account = google_service_account.f5_bigip_user.email
-  mgmt_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "" }]
+  mgmt_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "network_id" = null, "subnet_project_id" = null }]
 }
 

--- a/examples/bigip_gcp_2nic_deploy/main.tf
+++ b/examples/bigip_gcp_2nic_deploy/main.tf
@@ -88,6 +88,6 @@ module "bigip" {
   zone                = var.zone
   image               = var.image
   service_account     = var.service_account
-  mgmt_subnet_ids     = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "" }]
-  external_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.external_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "private_ip_secondary" = "" }]
+  mgmt_subnet_ids     = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "network_id" = null, "subnet_project_id" = null }]
+  external_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.external_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "private_ip_secondary" = "", "network_id" = null, "subnet_project_id" = null }]
 }

--- a/examples/bigip_gcp_3nic_deploy/main.tf
+++ b/examples/bigip_gcp_3nic_deploy/main.tf
@@ -86,7 +86,7 @@ module "bigip" {
   zone                = var.zone
   image               = var.image
   service_account     = var.service_account
-  mgmt_subnet_ids     = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "" }]
-  external_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.external_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "private_ip_secondary" = "" }]
-  internal_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.internal_subnetwork.id, "public_ip" = false, "private_ip_primary" = "", "private_ip_secondary" = "" }]
+  mgmt_subnet_ids     = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "network_id" = null, "subnet_project_id" = null }]
+  external_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.external_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "private_ip_secondary" = "", "network_id" = null, "subnet_project_id" = null }]
+  internal_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.internal_subnetwork.id, "public_ip" = false, "private_ip_primary" = "", "private_ip_secondary" = "", "network_id" = null, "subnet_project_id" = null }]
 }

--- a/examples/bigip_gcp_4nic_deploy/main.tf
+++ b/examples/bigip_gcp_4nic_deploy/main.tf
@@ -116,8 +116,8 @@ module "bigip" {
   zone                = var.zone
   image               = var.image
   service_account     = var.service_account
-  mgmt_subnet_ids     = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "" }]
-  external_subnet_ids = ([{ "subnet_id" = google_compute_subnetwork.external_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "private_ip_secondary" = "" }, { "subnet_id" = google_compute_subnetwork.external_subnetwork2.id, "public_ip" = true, "private_ip_primary" = "", "private_ip_secondary" = "" }])
-  internal_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.internal_subnetwork.id, "public_ip" = false, "private_ip_primary" = "" }]
+  mgmt_subnet_ids     = [{ "subnet_id" = google_compute_subnetwork.mgmt_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "network_id" = null, "subnet_project_id" = null }]
+  external_subnet_ids = ([{ "subnet_id" = google_compute_subnetwork.external_subnetwork.id, "public_ip" = true, "private_ip_primary" = "", "private_ip_secondary" = "", "network_id" = null, "subnet_project_id" = null }, { "subnet_id" = google_compute_subnetwork.external_subnetwork2.id, "public_ip" = true, "private_ip_primary" = "", "private_ip_secondary" = "", "network_id" = null, "subnet_project_id" = null }])
+  internal_subnet_ids = [{ "subnet_id" = google_compute_subnetwork.internal_subnetwork.id, "public_ip" = false, "private_ip_primary" = "", "network_id" = null, "subnet_project_id" = null }]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -167,7 +167,9 @@ resource "google_compute_instance" "f5vm01" {
   dynamic "network_interface" {
     for_each = [for subnet in var.external_subnet_ids : subnet if subnet.subnet_id != null && subnet.subnet_id != ""]
     content {
+      network = network_interface.value.network_id
       subnetwork = network_interface.value.subnet_id
+      subnetwork_project = network_interface.value.subnet_project_id
       network_ip = network_interface.value.private_ip_primary
       dynamic "access_config" {
         for_each = element(coalescelist(compact([network_interface.value.public_ip]), [false]), 0) ? [1] : []
@@ -189,7 +191,9 @@ resource "google_compute_instance" "f5vm01" {
   dynamic "network_interface" {
     for_each = [for subnet in var.mgmt_subnet_ids : subnet if subnet.subnet_id != null && subnet.subnet_id != ""]
     content {
+      network = network_interface.value.network_id
       subnetwork = network_interface.value.subnet_id
+      subnetwork_project = network_interface.value.subnet_project_id
       network_ip = network_interface.value.private_ip_primary
       dynamic "access_config" {
         for_each = element(coalescelist(compact([network_interface.value.public_ip]), [false]), 0) ? [1] : []
@@ -207,7 +211,9 @@ resource "google_compute_instance" "f5vm01" {
   dynamic "network_interface" {
     for_each = [for subnet in var.internal_subnet_ids : subnet if subnet.subnet_id != null && subnet.subnet_id != ""]
     content {
+      network = network_interface.value.network_id
       subnetwork = network_interface.value.subnet_id
+      subnetwork_project = network_interface.value.subnet_project_id
       network_ip = network_interface.value.private_ip_primary
       dynamic "access_config" {
         for_each = element(coalescelist(compact([network_interface.value.public_ip]), [false]), 0) ? [1] : []

--- a/variables.tf
+++ b/variables.tf
@@ -62,32 +62,38 @@ variable "disk_size_gb" {
 variable "mgmt_subnet_ids" {
   description = "List of maps of subnetids of the virtual network where the virtual machines will reside."
   type = list(object({
+    network_id         = string
     subnet_id          = string
+    subnet_project_id  = string
     public_ip          = bool
     private_ip_primary = string
   }))
-  default = [{ "subnet_id" = null, "public_ip" = null, "private_ip_primary" = null }]
+  default = [{ "network_id" = null, "subnet_id" = null, "subnet_project_id" = null, "public_ip" = null, "private_ip_primary" = null }]
 }
 
 variable "external_subnet_ids" {
   description = "List of maps of subnetids of the virtual network where the virtual machines will reside."
   type = list(object({
+    network_id           = string
     subnet_id            = string
+    subnet_project_id    = string
     public_ip            = bool
     private_ip_primary   = string
     private_ip_secondary = string
   }))
-  default = [{ "subnet_id" = null, "public_ip" = null, "private_ip_primary" = null, "private_ip_secondary" = null }]
+  default = [{ "network_id" = null, "subnet_id" = null, "subnet_project_id" = null, "public_ip" = null, "private_ip_primary" = null, "private_ip_secondary" = null }]
 }
 
 variable "internal_subnet_ids" {
   description = "List of maps of subnetids of the virtual network where the virtual machines will reside."
   type = list(object({
-    subnet_id          = string
-    public_ip          = bool
-    private_ip_primary = string
+    network_id           = string
+    subnet_id            = string
+    subnet_project_id    = string
+    public_ip            = bool
+    private_ip_primary   = string
   }))
-  default = [{ "subnet_id" = null, "public_ip" = null, "private_ip_primary" = null }]
+  default = [{ "network_id" = null, "subnet_id" = null, "subnet_project_id" = null, "public_ip" = null, "private_ip_primary" = null }]
 }
 
 


### PR DESCRIPTION
Hello,

this PR adds ability to use shared VPC when configuring NIC. 
It adds two variables:
`network_id` - to be able to specify parent network VPC.
`subnet_project_id` - to be able to specify the project which shares a subnetwork into your google project.

Both parameters are optional and can be set to `null` to not use them. But it is required to have them if you want to be able to use shared VPC. 

Let me know if there are any other changes required to be able to merge this. 
I updated README and examples.